### PR TITLE
Changed canvas dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "yargs": "~1.2.1",
-    "canvas": "~1.2.10",
+    "canvas": "~1.3.*",
     "smartcrop": "~0.0.0",
     "underscore": "~1.6.0"
   }


### PR DESCRIPTION
Changed canvas version so it could install on MacOS.
With 1.2.10, install would fail with canvas being unable to build. The bug has been fixed since in 1.3.x versions.
Tested on my side, without errors.
